### PR TITLE
Release 1.2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,11 +9,13 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* Add `maven enforcer plugin <https://maven.apache.org/enforcer/maven-enforcer-plugin>`_ to show dependency conflicts
+
 **Fixed**
 
 **Dependencies**
 
-* Bump ``data-model-lib:2.0.0`` -> ``2.4.0``
+* Bump ``data-model-lib:2.0.0`` -> ``2.4.0`` (`#8 <https://github.com/qbicsoftware/sample-status-updater-cli/pull/8>`_)
 
 **Deprecated**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.3.0-SNAPSHOT (2021-03-23)
+---------------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+* Bump ``data-model-lib:2.0.0`` -> ``2.4.0``
+
+**Deprecated**
 
 1.2.1 (2021-03-02)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.2.2 (2021-03-23)
+1.2.2 (2021-03-25)
 ---------------------------
 
 **Added**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.3.0-SNAPSHOT (2021-03-23)
+1.2.2 (2021-03-23)
 ---------------------------
 
 **Added**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/qbicsoftware/sample-status-updater-cli.svg?branch=development)](https://travis-ci.com/qbicsoftware/sample-status-updater-cli)[![Code Coverage]( https://codecov.io/gh/qbicsoftware/sample-status-updater-cli/branch/development/graph/badge.svg)](https://codecov.io/gh/qbicsoftware/sample-status-updater-cli)
 
-Sample command-line Tool, version 1.0.0-SNAPSHOT - Command-line utility to...
+Sample command-line Tool - Command-line utility to add the first location of sample tracking information
 
 ## Author
 Created by Sven Fillinger (sven.fillinger@qbic.uni-tuebingen.de).

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<version>2.1.0</version>
 	</parent>
 	<artifactId>sample-status-updater-cli</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.3.0-SNAPSHOT</version>
 	<name>sample status updater app</name>
 	<url>http://github.com/qbicsoftware/sample-status-updater-cli</url>
 	<description>Command-line utility to add the first location of sample tracking information</description>

--- a/pom.xml
+++ b/pom.xml
@@ -66,4 +66,29 @@
 			<version>3-S253.0</version>
 		</dependency>
     </dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M2</version>
+				<executions>
+					<execution>
+						<id>default-cli</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<dependencyConvergence/>
+								<banDuplicatePomDependencyVersions/>
+							</rules>
+							<fail>false</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>data-model-lib</artifactId>
-			<version>2.0.0</version>
+			<version>2.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>life.qbic.openbis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<version>2.1.0</version>
 	</parent>
 	<artifactId>sample-status-updater-cli</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>1.2.2</version>
 	<name>sample status updater app</name>
 	<url>http://github.com/qbicsoftware/sample-status-updater-cli</url>
 	<description>Command-line utility to add the first location of sample tracking information</description>

--- a/sample-status-updater-application/pom.xml
+++ b/sample-status-updater-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-status-updater-cli</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,13 +14,13 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>sample-status-updater-infrastructure</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>sample-status-updater-domain</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/sample-status-updater-application/pom.xml
+++ b/sample-status-updater-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-status-updater-cli</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,13 +14,13 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>sample-status-updater-infrastructure</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>sample-status-updater-domain</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/sample-status-updater-domain/pom.xml
+++ b/sample-status-updater-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-status-updater-cli</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sample-status-updater-domain/pom.xml
+++ b/sample-status-updater-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-status-updater-cli</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sample-status-updater-infrastructure/pom.xml
+++ b/sample-status-updater-infrastructure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-status-updater-cli</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>sample-status-updater-domain</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 

--- a/sample-status-updater-infrastructure/pom.xml
+++ b/sample-status-updater-infrastructure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-status-updater-cli</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>1.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>sample-status-updater-domain</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.2.2</version>
             <scope>compile</scope>
         </dependency>
 

--- a/sample-status-updater-infrastructure/src/main/groovy/life/qbic/samplestatusupdater/search/SampleSearchConnector.groovy
+++ b/sample-status-updater-infrastructure/src/main/groovy/life/qbic/samplestatusupdater/search/SampleSearchConnector.groovy
@@ -17,7 +17,6 @@ class SampleSearchConnector implements OpenBisSearchService {
 
     @Override
     List<String> findNewOpenBisSamplesSince(Date registeredSince, List sampleTypeFilter) {
-        println sampleTypeFilter
         def criteria = new SampleSearchCriteria()
         criteria.withRegistrationDate().thatIsLaterThanOrEqualTo(registeredSince)
 

--- a/sample-status-updater-infrastructure/src/main/groovy/life/qbic/samplestatusupdater/update/SampleTrackingServiceConnector.groovy
+++ b/sample-status-updater-infrastructure/src/main/groovy/life/qbic/samplestatusupdater/update/SampleTrackingServiceConnector.groovy
@@ -34,7 +34,7 @@ class SampleTrackingServiceConnector implements SampleTrackingService {
     }
 
     @Override
-    def registerFirstSampleLocation(String sampleCode, Location location) throws SampleUpdateException{
+    def registerFirstSampleLocation(String sampleCode, Location location) {
         HttpClient client = RxHttpClient.create(service.rootUrl)
         //TODO this is only a workaround, as the client seems not to prepend the base url.
         URI sampleUri = new URI("${service.rootUrl.toExternalForm()}/samples/$sampleCode/")
@@ -51,6 +51,7 @@ class SampleTrackingServiceConnector implements SampleTrackingService {
                 log.info "Sample $sampleCode not yet registered, setting first sample location QBiC..."
                 updateSampleLocation(sampleCode, location)
             } else {
+                log.error("Http response exception: ${e.message}, ${e.response}")
                 throw new HttpClientResponseException(e.message, e.response)
             }
         }


### PR DESCRIPTION
1.2.2 (2021-03-25)
---------------------------

**Added**

* Add `maven enforcer plugin <https://maven.apache.org/enforcer/maven-enforcer-plugin>`_ to show dependency conflicts

**Fixed**

**Dependencies**

* Bump ``data-model-lib:2.0.0`` -> ``2.4.0`` (`#8 <https://github.com/qbicsoftware/sample-status-updater-cli/pull/8>`_)

**Deprecated**
