### PR TITLE
Hotfix 1.2.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.2.3 (2021-03-25)
+---------------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+* Bump ``cli-parent-pom:2.1.0`` -> ``3.1.4`` (`#10 <https://github.com/qbicsoftware/sample-status-updater-cli/pull/10>`_)
+
+**Deprecated**
+
 1.2.2 (2021-03-25)
 ---------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
     <parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>cli-parent-pom</artifactId>
-		<version>2.1.0</version>
+		<version>3.1.4</version>
 	</parent>
 	<artifactId>sample-status-updater-cli</artifactId>
-	<version>1.2.2</version>
+	<version>1.2.3</version>
 	<name>sample status updater app</name>
 	<url>http://github.com/qbicsoftware/sample-status-updater-cli</url>
 	<description>Command-line utility to add the first location of sample tracking information</description>

--- a/sample-status-updater-application/pom.xml
+++ b/sample-status-updater-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-status-updater-cli</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.2.2</version>
+        <version>1.2.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,13 +14,13 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>sample-status-updater-infrastructure</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>sample-status-updater-domain</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/sample-status-updater-domain/pom.xml
+++ b/sample-status-updater-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-status-updater-cli</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.2.2</version>
+        <version>1.2.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sample-status-updater-infrastructure/pom.xml
+++ b/sample-status-updater-infrastructure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-status-updater-cli</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.2.2</version>
+        <version>1.2.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>sample-status-updater-domain</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
1.2.3 (2021-03-25)
---------------------------

**Added**

**Fixed**

**Dependencies**

* Bump ``cli-parent-pom:2.1.0`` -> ``3.1.4`` (<https://github.com/qbicsoftware/sample-status-updater-cli/pull/10>)

**Deprecated**