### PR TITLE
only track analyte samples

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.4.0-SNAPSHOT (2021-12-22)
+---------------------------
+
+**Added**
+
+* Only "Q_TEST_SAMPLES" are added to the database. This makes tracking of lab processes more intuitive.
+
+**Fixed**
+
+**Dependencies**
+
+**Deprecated**
+
 1.3.0-SNAPSHOT (2021-03-23)
 ---------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<version>2.1.0</version>
 	</parent>
 	<artifactId>sample-status-updater-cli</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>1.4.0-SNAPSHOT</version>
 	<name>sample status updater app</name>
 	<url>http://github.com/qbicsoftware/sample-status-updater-cli</url>
 	<description>Command-line utility to add the first location of sample tracking information</description>

--- a/sample-status-updater-domain/src/main/groovy/life.qbic.samplestatusupdater.search/SampleTypeFilter.groovy
+++ b/sample-status-updater-domain/src/main/groovy/life.qbic.samplestatusupdater.search/SampleTypeFilter.groovy
@@ -9,10 +9,7 @@ class SampleTypeFilter<String> extends ArrayList<String> {
 
     SampleTypeFilter() {
         this.addAll(
-                ["Q_TEST_SAMPLE",
-                  "Q_BIOLOGICAL_ENTITY",
-                  "Q_BIOLOGICAL_SAMPLE",
-                 ])
+                ["Q_TEST_SAMPLE"])
     }
 
 }


### PR DESCRIPTION
* only analyte samples (openbis type code: Q_TEST_SAMPLE) are added to the tracking database